### PR TITLE
Ensure all videos have audio

### DIFF
--- a/get.rb
+++ b/get.rb
@@ -98,7 +98,7 @@ CONFIG["youtube_channels"].each do |channel_url|
   FileUtils.mkdir_p(storage_dir)
   Dir.chdir(storage_dir) do
     puts "Updating #{ channel_url }"
-    cmd(*%W[#{YOUTUBE_DL} --id -w --write-thumbnail -f webm/bestaudio --download-archive ../#{ external_id }.index #{ channel_url }])
+    cmd(*%W[#{YOUTUBE_DL} --id -w --write-thumbnail -f 248+251/bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4' --download-archive ../#{ external_id }.index #{ channel_url }])
   end
 
   video_ids = File.read("#{ CONFIG["storage_path"] }/#{ external_id }.index").lines.map{|l| l.split.last}

--- a/lib/notube/views/video.erb
+++ b/lib/notube/views/video.erb
@@ -12,6 +12,7 @@
   <div class="video-player">
     <video width="100%" controls="controls" poster="/data/<%= @video.channel.external_id %>/<%= @video.external_id %>.jpg">
       <source src="/data/<%= @video.channel.external_id %>/<%= @video.external_id %>.webm">
+      <source src="/data/<%= @video.channel.external_id %>/<%= @video.external_id %>.mp4">
     </video>
   </div>
 


### PR DESCRIPTION
Previously, by specifying only `webm` as a format, we were often only
downloading a video-only format. This updates the format preference
string to prefer "248+251" which is webm + opus, falling back to the
best MP4 we can find, thus covering 99% of cases.