### PR TITLE
Add "next up" page 

### DIFF
--- a/lib/notube/application.rb
+++ b/lib/notube/application.rb
@@ -10,21 +10,23 @@ module Notube
     set :storage_path, CONFIG["storage_path"]
 
     get "/" do
-      @channels = settings.db.execute("select id,external_id,name from channels")
-      @videos = settings.db.select(Models::Video, <<-SQL)
-        select * from videos order by videos.published_at desc limit 10
-      SQL
-
-      erb :home
-    end
-
-    get "/next" do
+      @page_class = "page-home"
       @channels = settings.db.execute("select id,external_id,name from channels")
       @videos = settings.db.select(Models::Video, <<-SQL)
         select * from videos where watched_at is null order by videos.published_at desc limit 10
       SQL
 
       erb :next
+    end
+
+    get "/recent" do
+      @page_class = "page-recent"
+      @channels = settings.db.execute("select id,external_id,name from channels")
+      @videos = settings.db.select(Models::Video, <<-SQL)
+        select * from videos order by videos.published_at desc limit 10
+      SQL
+
+      erb :recent
     end
 
     get "/videos/:id" do

--- a/lib/notube/application.rb
+++ b/lib/notube/application.rb
@@ -18,6 +18,15 @@ module Notube
       erb :home
     end
 
+    get "/next" do
+      @channels = settings.db.execute("select id,external_id,name from channels")
+      @videos = settings.db.select(Models::Video, <<-SQL)
+        select * from videos where watched_at is null order by videos.published_at desc limit 10
+      SQL
+
+      erb :next
+    end
+
     get "/videos/:id" do
       @channels = settings.db.execute("select id,external_id,name from channels")
 

--- a/lib/notube/views/layout.erb
+++ b/lib/notube/views/layout.erb
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="/css/app.css" type="text/css">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 </head>
-<body>
+<body class="<%= @page_class %>">
   <header class="app-header">
     <h1><a href="/">
       <img src="/icon.svg" alt="notube icon">
@@ -13,8 +13,8 @@
     </a></h1>
 
     <nav>
-      <a href="/">Latest</a>
-      <a href="/next">Next Up</a>
+      <a id="navHome" href="/">Next Up</a>
+      <a id="navRecent" href="/recent">Recently Posted</a>
     </nav>
   </header>
 

--- a/lib/notube/views/layout.erb
+++ b/lib/notube/views/layout.erb
@@ -11,6 +11,11 @@
       <img src="/icon.svg" alt="notube icon">
       <span>notube&trade;
     </a></h1>
+
+    <nav>
+      <a href="/">Latest</a>
+      <a href="/next">Next Up</a>
+    </nav>
   </header>
 
   <div class="app-wrapper">

--- a/lib/notube/views/next.erb
+++ b/lib/notube/views/next.erb
@@ -1,5 +1,6 @@
-<header class="video-cards-header">
+<header class="video-header video-header-category">
   <h2>Next Up</h2>
+  <div class="subtitle">The most recent unwatched videos from your subscriptions.</div>
 </header>
 <div class="video-cards">
   <% @videos.each do |v| %>

--- a/lib/notube/views/next.erb
+++ b/lib/notube/views/next.erb
@@ -1,0 +1,8 @@
+<header class="video-cards-header">
+  <h2>Next Up</h2>
+</header>
+<div class="video-cards">
+  <% @videos.each do |v| %>
+    <%= erb :video_card, locals: { video: v } %>
+  <% end %>
+</div>

--- a/lib/notube/views/recent.erb
+++ b/lib/notube/views/recent.erb
@@ -1,5 +1,6 @@
-<header class="video-cards-header">
+<header class="video-header video-header-category">
   <h2>Recently Posted</h2>
+  <div class="subtitle">The most recent videos from your subscriptions.</div>
 </header>
 <div class="video-cards">
   <% @videos.each do |v| %>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -71,6 +71,12 @@ a {
   .app-header nav a:hover {
     background-color: rgba(0,0,0, 0.1);
   }
+  .page-home #navHome,
+  .page-recent #navRecent,
+  .app-header nav .current {
+    background: rgba(255,255,255, 0.9);
+    color: var(--color-highlight);
+  }
 
 .app-wrapper {
   display: flex;
@@ -128,10 +134,6 @@ a {
   padding: 1rem;
 }
 
-.video-cards-header {
-  padding: 1rem;
-}
-
 .video-card {
   position: relative;
   box-sizing: border-box;
@@ -175,6 +177,21 @@ a {
   padding: 1rem;
   border-bottom: 1px solid var(--color-border);
 }
+  .video-header h2 {
+    margin: 0;
+  }
+  .video-header .subtitle {
+    color: var(--color-text-light);
+  }
+
+.video-header-category {
+  display: flex;
+  align-items: center;
+  padding: 2rem;
+}
+  .video-header-category h2 {
+    margin-right: 1rem;
+  }
 
 .video-meta {
   display: flex;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -17,6 +17,7 @@
 
   --height-header: 2rem;
   --padding-header: 1em;
+  --width-sidebar: 16rem;
 }
 
 
@@ -39,12 +40,14 @@ a {
  ******************************************************************************/
 
 .app-header {
+  display: flex;
   padding: var(--padding-header);
   height: var(--height-header);
   background-color: var(--color-highlight);
 }
   .app-header h1 {
     margin: 0;
+    width: var(--width-sidebar);
     font-size: 1em;
   }
   .app-header a {
@@ -59,13 +62,23 @@ a {
     margin-right: 0.5rem;
   }
 
+  .app-header nav a {
+    display: inline-block;
+    height: var(--height-header);
+    line-height: var(--height-header);
+    padding: 0 var(--padding-header);
+  }
+  .app-header nav a:hover {
+    background-color: rgba(0,0,0, 0.1);
+  }
+
 .app-wrapper {
   display: flex;
   align-items: stretch;
 }
 
 .app-sidebar {
-  width: 20rem;
+  min-width: var(--width-sidebar);
   background-color: var(--color-background-grey);
   border-right: 1px solid var(--color-border);
 }


### PR DESCRIPTION
This updates the homepage to show "next up" - which excludes previously-watched videos. The old home page content is now accessible through a new global nav menu on a "recently posted" page.