### PR TITLE
Name the database after the current RACK_ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /static/data
 /config.yml
-/library.db
+/*.db

--- a/lib/notube/database.rb
+++ b/lib/notube/database.rb
@@ -1,10 +1,9 @@
 module Notube
   class Database
 
-    DATABASE_NAME = "library.db".freeze
-
     def initialize
-      @db = SQLite3::Database.new(DATABASE_NAME)
+      environment = ENV.fetch("RACK_ENV", "development")
+      @db = SQLite3::Database.new("#{ environment }.db")
     end
 
     # Find a model by its ID.


### PR DESCRIPTION
This will allow us to separate development, test, and production data.