### PR TITLE
Ensure a video ID with a dash isn't parsed

### DIFF
--- a/lib/notube/fetch.rb
+++ b/lib/notube/fetch.rb
@@ -104,7 +104,7 @@ module Notube
       FileUtils.mkdir_p(storage_dir)
 
       Dir.chdir(storage_dir) do
-        cmd(*%W[#{YOUTUBE_DL} --id -f 248+251/bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4' #{ video.external_id }])
+        cmd(*%W[#{YOUTUBE_DL} --id -f 248+251/bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4' -- #{ video.external_id }])
       end
 
       @db.execute("update videos set downloaded_at = CURRENT_TIMESTAMP where id = ?", video.id)


### PR DESCRIPTION
Some youtube video ID's begin with a `-` character, which tricks
youtubedl into parsing it as flags. We should ensure that the video ID
is never ambiguous and always is left unparsed.