### PR TITLE
QOL tweaks

### DIFF
--- a/lib/notube/application.rb
+++ b/lib/notube/application.rb
@@ -8,12 +8,13 @@ module Notube
     set :youtube_api_key, CONFIG["youtube_api_key"]
     set :youtube_channels, CONFIG["youtube_channels"]
     set :storage_path, CONFIG["storage_path"]
+    set :per_page, 30
 
     get "/" do
       @page_class = "page-home"
       @channels = settings.db.execute("select id,external_id,name from channels")
       @videos = settings.db.select(Models::Video, <<-SQL)
-        select * from videos where watched_at is null order by videos.published_at desc limit 10
+        select * from videos where watched_at is null order by videos.published_at desc limit #{settings.per_page}
       SQL
 
       erb :next
@@ -23,7 +24,7 @@ module Notube
       @page_class = "page-recent"
       @channels = settings.db.execute("select id,external_id,name from channels")
       @videos = settings.db.select(Models::Video, <<-SQL)
-        select * from videos order by videos.published_at desc limit 10
+        select * from videos order by videos.published_at desc limit #{settings.per_page}
       SQL
 
       erb :recent
@@ -49,7 +50,7 @@ module Notube
       @videos = settings.db.select(Models::Video, <<-SQL, params[:id], params[:before])
         select * from videos
         where videos.channel_id = ? and published_at < ?
-        order by published_at desc limit 25
+        order by published_at desc limit #{settings.per_page}
       SQL
 
       @next_offset = @videos.last.published_at unless @videos.empty?

--- a/lib/notube/views/video.erb
+++ b/lib/notube/views/video.erb
@@ -24,19 +24,25 @@
   <% else %>
     <div class="video-download">
       This video has not yet been downloaded.
-      <a href="/download/<%= @video.id %>" id="downloadLink">Begin Download</a>
+      <a href="/download/<%= @video.id %>" class="js-download-link">Begin Download</a>
     </div>
+
+    <a href="/download/<%= @video.id %>" class="video-preview-download js-download-link" style="display: block;">
+      <img src="/data/<%= @video.channel.external_id %>/<%= @video.external_id %>.jpg" width="100%">
+    </a>
 
     <script>
       (function () {
-        let downloadLink = document.getElementById("downloadLink");
+        let downloadLinks = document.querySelectorAll(".js-download-link");
 
-        downloadLink.addEventListener("click", function(ev) {
-          ev.preventDefault();
-          fetch(ev.currentTarget.getAttribute("href")).then(() => {
-            window.location.reload()
+        downloadLinks.forEach(function (el) {
+          el.addEventListener("click", function(ev) {
+            ev.preventDefault();
+            fetch(ev.currentTarget.getAttribute("href")).then(() => {
+              window.location.reload()
+            })
           })
-        })
+        );
       })();
     </script>
   <% end %>


### PR DESCRIPTION
This bumps the videos per-page to 30 (an moves it to a sinatra setting). This also adds a clickable large preview of the video on the download page if it isn't downloaded. It could probably use a little download icon over it to help indicate what it is, but I think this is better anyways.