### PR TITLE
Update rack for security release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rspec (3.8.0)
@@ -53,4 +53,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
Addressed CVE-2018-16471 and CVE-2018-16470 (both moderate) which are
resolved in Rack 2.0.6.